### PR TITLE
core: more descriptive vendor image mismatch message

### DIFF
--- a/core/res/res/values/cm_strings.xml
+++ b/core/res/res/values/cm_strings.xml
@@ -152,4 +152,8 @@
 
     <!-- Notify user that they are in Lock-to-app (for devices without navbar) -->
     <string name="lock_to_app_toast_no_navbar">To unpin this screen, touch and hold the Back button.</string>
+
+    <!-- Message to show the user when their vendor image doesn't match the build's fingerprint. -->
+    <string name="lineage_system_error_manufacturer">A vendor image mismatch has been detected. Typically this means your vendor image is out of date. Please ensure your vendor image matches <xliff:g id="fingerprint">%1$s</xliff:g>.</string>
+
 </resources>

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -82,4 +82,7 @@
 
     <!-- Blur effects -->
     <java-symbol type="bool" name="config_uiBlurEnabled" />
+
+    <!-- Message to show the user when their vendor image doesn't match the build's fingerprint. -->
+    <java-symbol type="string" name="lineage_system_error_manufacturer" />
 </resources>

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -1714,7 +1714,8 @@ public final class ActivityManagerService extends ActivityManagerNative
                     d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                     d.setCancelable(false);
                     d.setTitle(mContext.getText(R.string.android_system_label));
-                    d.setMessage(mContext.getText(R.string.system_error_manufacturer));
+                    d.setMessage(mContext.getString(R.string.lineage_system_error_manufacturer,
+                            SystemProperties.get("ro.build.fingerprint").split("/")[3]));
                     d.setButton(DialogInterface.BUTTON_POSITIVE, mContext.getText(R.string.ok),
                             obtainMessage(DISMISS_DIALOG_UI_MSG, d));
                     d.show();


### PR DESCRIPTION
* On lineage, we don't update users' vendor images. This can
  cause an issue when the fingerprint of the rom doesn't match
  the fingerprint on the vendor image. Let's use a more descriptive
  message to tell the user what needs to be done, rather than telling
  them to contact their manufacturer.

Change-Id: I8ffd0fb7347454a52aa71498719a407447e6e8f4