### PR TITLE
PhoneWindowManager: add mTopFullscreenOpaqueWindowState null check to…

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -6624,8 +6624,9 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             }
 
             case KeyEvent.KEYCODE_POWER: {
-                if ((mTopFullscreenOpaqueWindowState.getAttrs().privateFlags
-                        & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0
+                if (mTopFullscreenOpaqueWindowState != null
+                        && (mTopFullscreenOpaqueWindowState.getAttrs().privateFlags
+                                & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0
                         && mScreenOnFully) {
                     return result;
                 }


### PR DESCRIPTION
… fix exception

Discovered through extensive testing with double press power for camera combined
with long press power for torch (though these features are not required to
trigger the issue), lack of null check here can occasionally result in either of:

1) screen is off, power press will NOT turn the screen on (needs to be woken
   via fingerprint, power cable connect or leave device for a minute or
   so and it will eventually wake on power press again).
OR
2) screen is on, power press will not turn the screen off

It requires pressing power shortly after screen off or screen on at just
the right time to trigger.  Issue is reproducible on angler.

E InputManager-JNI: An exception was thrown by callback 'interceptKeyBeforeQueueing'.
E InputManager-JNI: java.lang.NullPointerException: Attempt to invoke interface method
 'android.view.WindowManager$LayoutParams android.view.WindowManagerPolicy$WindowState.getAttrs()'
on a null object reference
E InputManager-JNI:      at com.android.server.policy.PhoneWindowManager.interceptKeyBeforeQueueing(PhoneWindowManager.java:6647)
E InputManager-JNI:      at com.android.server.wm.InputMonitor.interceptKeyBeforeQueueing(InputMonitor.java:399)
E InputManager-JNI:      at com.android.server.input.InputManagerService.interceptKeyBeforeQueueing(InputManagerService.java:1979)

Change-Id: I77d094130d58b152fdfa515f53661543976b33bf