### PR TITLE
Show infinity for large notification counts

### DIFF
--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -132,4 +132,10 @@
         <item></item> <!-- STREAM_DTMF -->
         <item></item> <!-- STREAM_TTS -->
     </string-array>
+
+    <!-- Text to use when the number in a notification info is too large
+         (greater than status_bar_notification_info_maxnum, defined in
+         values/config.xml) and must be truncated.
+         [CHAR LIMIT=4] -->
+    <string name="status_bar_notification_info_overflow" translatable="false">\u221E</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
@@ -321,7 +321,7 @@ public class StatusBarIconView extends AnimatedImageView {
                 android.R.integer.status_bar_notification_info_maxnum);
         if (mIcon.number > tooBig) {
             str = getContext().getResources().getString(
-                        android.R.string.status_bar_notification_info_overflow);
+                        R.string.status_bar_notification_info_overflow);
         } else {
             NumberFormat f = NumberFormat.getIntegerInstance();
             str = f.format(mIcon.number);


### PR DESCRIPTION
This patch adds a new string to SystemUI for displaying the infinity
symbol when a notification has a count larger than 999.  This only
affects the notification icon in the status bar and does not change
the text displayed in the actual notification.

These changes were manually cherry-picked from cm-13.0.

Change-Id: I3481aac13cd90ee20ed48194df3ec789c16c8b4b