### PR TITLE
base: instrumentation: fix protected apps intents

### DIFF
--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -130,6 +130,12 @@ public class ActivityManager {
     public static final String META_HOME_ALTERNATE = "android.app.home.alternate";
 
     /**
+     * Result for IActivityManager.startActivity: trying to start a protected app.
+     * @hide
+     */
+    public static final int START_PROTECTED_APP = -11;
+
+    /**
      * Result for IActivityManager.startVoiceActivity: active session is currently hidden.
      * @hide
      */

--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -1801,7 +1801,9 @@ public class Instrumentation {
 
     /** @hide */
     public static void checkStartActivityResult(int res, Object intent) {
-        if (res >= ActivityManager.START_SUCCESS) {
+        // Allow START_PROTECTED_APP for protected apps
+        if (res >= ActivityManager.START_SUCCESS ||
+                res == ActivityManager.START_PROTECTED_APP) {
             return;
         }
 

--- a/services/core/java/com/android/server/am/ActivityStarter.java
+++ b/services/core/java/com/android/server/am/ActivityStarter.java
@@ -377,11 +377,11 @@ class ActivityStarter {
                     intent.putExtra("com.android.settings.PROTECTED_APPS_USER_ID", userId);
                     msg.obj = intent;
                     mService.mHandler.sendMessage(msg);
-                    err = ActivityManager.START_NOT_CURRENT_USER_ACTIVITY;
+                    err = ActivityManager.START_PROTECTED_APP;
                 }
             } catch (RemoteException e) {
                 Slog.w(TAG, "Failure checking protected apps status", e);
-                err = ActivityManager.START_NOT_CURRENT_USER_ACTIVITY;
+                err = ActivityManager.START_PROTECTED_APP;
             }
         }
 
@@ -808,7 +808,7 @@ class ActivityStarter {
                     intent.putExtra("com.android.settings.PROTECTED_APPS_USER_ID", userId);
                     msg.obj = intent;
                     mService.mHandler.sendMessage(msg);
-                    return ActivityManager.START_NOT_CURRENT_USER_ACTIVITY;
+                    return ActivityManager.START_PROTECTED_APP;
                 }
             } catch (RemoteException e) {
                 e.printStackTrace();


### PR DESCRIPTION
When an app launches a protected app, it crashes because the intent result is
START_NOT_CURRENT_USER_ACTIVITY instead of START_SUCCESS, add a new special case
for protected app intents

Ticket: LINN-18

Change-Id: I9736829117382e44dc42fb79c8e1902a55625a56
Signed-off-by: Joey Rizzoli <joey@lineageos.org>