### PR TITLE
Disable quick pulldown by default

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -2453,7 +2453,7 @@ public class NotificationPanelView extends PanelView implements
                 break;
             case STATUS_BAR_QUICK_QS_PULLDOWN:
                 mOneFingerQuickSettingsIntercept =
-                        newValue == null ? 1 : Integer.parseInt(newValue);
+                        newValue == null ? 0 : Integer.parseInt(newValue);
                 break;
             case LOCK_SCREEN_WEATHER_ENABLED:
                 final boolean wasKeyguardWeatherEnabled = mKeyguardWeatherEnabled;


### PR DESCRIPTION
With Android N this feature became less relevant since a subset of
the toggles is available without fully expanding the notification
panel. This gives better access to the notifications with almost no
functionality loss.

Change-Id: Idb66472b77e60f4ae753c5dd00f6588566cc3c63