### PR TITLE
Fix intermittent slowness in resolver activity towards end of day.

### DIFF
--- a/services/usage/java/com/android/server/usage/UsageStatsXml.java
+++ b/services/usage/java/com/android/server/usage/UsageStatsXml.java
@@ -55,12 +55,13 @@ public class UsageStatsXml {
         }
     }
 
-    public static void read(AtomicFile file, IntervalStats statsOut) throws IOException {
+    public static void read(AtomicFile file, IntervalStats statsOut, int flags)
+            throws IOException {
         try {
             FileInputStream in = file.openRead();
             try {
                 statsOut.beginTime = parseBeginTime(file);
-                read(in, statsOut);
+                read(in, statsOut, flags);
                 statsOut.lastTimeSaved = file.getLastModifiedTime();
             } finally {
                 try {
@@ -87,7 +88,7 @@ public class UsageStatsXml {
         }
     }
 
-    static void read(InputStream in, IntervalStats statsOut) throws IOException {
+    static void read(InputStream in, IntervalStats statsOut, int flags) throws IOException {
         XmlPullParser parser = Xml.newPullParser();
         try {
             parser.setInput(in, "utf-8");
@@ -96,7 +97,7 @@ public class UsageStatsXml {
             try {
                 switch (Integer.parseInt(versionStr)) {
                     case 1:
-                        UsageStatsXmlV1.read(parser, statsOut);
+                        UsageStatsXmlV1.read(parser, statsOut, flags);
                         break;
 
                     default:

--- a/services/usage/java/com/android/server/usage/UserUsageStatsService.java
+++ b/services/usage/java/com/android/server/usage/UserUsageStatsService.java
@@ -231,7 +231,7 @@ class UserUsageStatsService {
      * provided to select the stats to use from the IntervalStats object.
      */
     private <T> List<T> queryStats(int intervalType, final long beginTime, final long endTime,
-            StatCombiner<T> combiner) {
+            int flags, StatCombiner<T> combiner) {
         if (intervalType == UsageStatsManager.INTERVAL_BEST) {
             intervalType = mDatabase.findBestFitBucket(beginTime, endTime);
             if (intervalType < 0) {
@@ -271,7 +271,7 @@ class UserUsageStatsService {
 
         // Get the stats from disk.
         List<T> results = mDatabase.queryUsageStats(intervalType, beginTime,
-                truncatedEndTime, combiner);
+                truncatedEndTime, flags, combiner);
         if (DEBUG) {
             Slog.d(TAG, "Got " + (results != null ? results.size() : 0) + " results from disk");
             Slog.d(TAG, "Current stats beginTime=" + currentStats.beginTime +
@@ -297,17 +297,20 @@ class UserUsageStatsService {
     }
 
     List<UsageStats> queryUsageStats(int bucketType, long beginTime, long endTime) {
-        return queryStats(bucketType, beginTime, endTime, sUsageStatsCombiner);
+        return queryStats(bucketType, beginTime, endTime,
+                UsageStatsDatabase.QUERY_FLAG_FETCH_PACKAGES, sUsageStatsCombiner);
     }
 
     List<ConfigurationStats> queryConfigurationStats(int bucketType, long beginTime, long endTime) {
-        return queryStats(bucketType, beginTime, endTime, sConfigStatsCombiner);
+        return queryStats(bucketType, beginTime, endTime,
+                UsageStatsDatabase.QUERY_FLAG_FETCH_CONFIGURATIONS, sConfigStatsCombiner);
     }
 
     UsageEvents queryEvents(final long beginTime, final long endTime) {
         final ArraySet<String> names = new ArraySet<>();
         List<UsageEvents.Event> results = queryStats(UsageStatsManager.INTERVAL_DAILY,
-                beginTime, endTime, new StatCombiner<UsageEvents.Event>() {
+                beginTime, endTime, UsageStatsDatabase.QUERY_FLAG_FETCH_EVENTS,
+                new StatCombiner<UsageEvents.Event>() {
                     @Override
                     public void combine(IntervalStats stats, boolean mutable,
                             List<UsageEvents.Event> accumulatedResult) {


### PR DESCRIPTION
The resolver calls UsageStatsManager.queryUsageStats() to get package
usage information. This causes all XMLs of the selected bucket to be
read, which can be of significant size. However, the majority of that
size is due to usage event information, which queryUsageStats() isn't
interested in, so it'll parse a lot of data just to throw it away later
on.
Solution: Don't parse the portions of the XMLs we aren't interested in.

Change-Id: Ia2595201c9fcceab2778618fd0cccfb19ad4ed8d