### PR TITLE
Move wakelock option for flashlight to CameraManager.

### DIFF
--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -32,6 +32,8 @@ import android.os.Binder;
 import android.os.DeadObjectException;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.ServiceSpecificException;
@@ -39,6 +41,8 @@ import android.os.SystemProperties;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.ArrayMap;
+
+import com.android.internal.R;
 
 import java.util.ArrayList;
 
@@ -71,6 +75,8 @@ public final class CameraManager {
 
     private ArrayList<String> mDeviceIdList;
 
+    private WakeLock mFlashlightWakeLock = null;
+
     private final Context mContext;
     private final Object mLock = new Object();
 
@@ -80,6 +86,36 @@ public final class CameraManager {
     public CameraManager(Context context) {
         synchronized(mLock) {
             mContext = context;
+
+            if (context.getResources().
+                    getBoolean(R.bool.config_useWakeLockForFlashlight)) {
+                PowerManager powerManager = (PowerManager)context.
+                        getSystemService(Context.POWER_SERVICE);
+                mFlashlightWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
+
+                TorchCallback torchCallback = new CameraManager.TorchCallback() {
+                    @Override
+                    public void onTorchModeUnavailable(String cameraId) {
+                        if (mFlashlightWakeLock.isHeld()) {
+                            mFlashlightWakeLock.release();
+                        }
+                    }
+
+                    @Override
+                    public void onTorchModeChanged(String cameraId, boolean enabled) {
+                        if (enabled) {
+                            if (!mFlashlightWakeLock.isHeld()) {
+                                mFlashlightWakeLock.acquire();
+                            }
+                        } else {
+                            if (mFlashlightWakeLock.isHeld()) {
+                                mFlashlightWakeLock.release();
+                            }
+                        }
+                    }
+                };
+                registerTorchCallback(torchCallback, null);
+            }
         }
     }
 

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2804,4 +2804,7 @@
 
     <!-- Whether to enable HumanInteractionController by default -->
     <bool name="config_HICEnabledDefault">true</bool>
+
+    <!-- Allow the flashlight to use wakelocks -->
+    <bool name="config_useWakeLockForFlashlight">false</bool>
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2817,4 +2817,7 @@
 
   <!-- Accelerometer batching -->
   <java-symbol type="bool" name="config_useDefaultBatchingForAccel" />
+
+  <!-- Allow devices to use wakelock for flashlight -->
+  <java-symbol type="bool" name="config_useWakeLockForFlashlight" />
 </resources>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -286,7 +286,4 @@
 
     <bool name="config_show4gForIWlan">false</bool>
     <bool name="config_showSignalForIWlan">false</bool>
-
-    <!-- Allow the flashlight service to use wakelocks -->
-    <bool name="config_useWakelockForFlashlight">false</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/FlashlightController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/FlashlightController.java
@@ -30,8 +30,6 @@ import android.hardware.camera2.CameraManager;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
-import android.os.PowerManager;
-import android.os.PowerManager.WakeLock;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -65,9 +63,6 @@ public class FlashlightController {
     /** Lock on mListeners when accessing */
     private final ArrayList<WeakReference<FlashlightListener>> mListeners = new ArrayList<>(1);
 
-    private final boolean mUseWakeLock;
-    private final WakeLock mWakeLock;
-
     /** Lock on {@code this} when accessing */
     private boolean mFlashlightEnabled;
 
@@ -96,10 +91,6 @@ public class FlashlightController {
         mContext = context;
         mCameraManager = (CameraManager) mContext.getSystemService(Context.CAMERA_SERVICE);
 
-        PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
-        mWakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
-        mUseWakeLock = mContext.getResources().getBoolean(R.bool.config_useWakelockForFlashlight);
-
         tryInitCamera();
     }
 
@@ -124,24 +115,12 @@ public class FlashlightController {
             if (mFlashlightEnabled != enabled) {
                 mFlashlightEnabled = enabled;
 
-                if (mUseWakeLock) {
-                    if (enabled) {
-                        if (!mWakeLock.isHeld()) mWakeLock.acquire();
-                    } else {
-                        if (mWakeLock.isHeld()) mWakeLock.release();
-                    }
-                }
-
                 try {
                     mCameraManager.setTorchMode(mCameraId, enabled);
                 } catch (CameraAccessException e) {
                     Log.e(TAG, "Couldn't set torch mode", e);
                     mFlashlightEnabled = false;
                     pendingError = true;
-
-                    if (mUseWakeLock && mWakeLock.isHeld()) {
-                        mWakeLock.release();
-                    }
                 }
             }
         }
@@ -321,10 +300,6 @@ public class FlashlightController {
             synchronized (FlashlightController.this) {
                 changed = mTorchAvailable != available;
                 mTorchAvailable = available;
-
-                if (mUseWakeLock && !available && mWakeLock.isHeld()) {
-                    mWakeLock.release();
-                }
             }
             if (changed) {
                 if (DEBUG) Log.d(TAG, "dispatchAvailabilityChanged(" + available + ")");
@@ -337,10 +312,6 @@ public class FlashlightController {
             synchronized (FlashlightController.this) {
                 changed = mFlashlightEnabled != enabled;
                 mFlashlightEnabled = enabled;
-
-                if (mUseWakeLock && !enabled && mWakeLock.isHeld()) {
-                    mWakeLock.release();
-                }
             }
             if (changed) {
                 if (DEBUG) Log.d(TAG, "dispatchModeChanged(" + enabled + ")");


### PR DESCRIPTION
On some legacy devices, the flashlight can't stay on when screen is off.
With this change, the flashlight can use wakelock. For obvious reasons,
this is turned off by default and needs to be enabled using the overlay.
See: https://review.lineageos.org/#/c/64929/

The wakelock-code and overlay is moved to CameraManager to be also effective
for the new long-press power torch feature.

BUGBASH-179

Change-Id: Iee905d4e5ca7a69219d9753167213fcb80d7c19e